### PR TITLE
Add multi album support to TraqLab

### DIFF
--- a/generate_songs_json.py
+++ b/generate_songs_json.py
@@ -1,0 +1,57 @@
+import argparse, glob, json, os, re
+from collections import defaultdict
+
+def parse_song_dir(path):
+    info = {}
+    base = os.path.basename(path)
+    m = re.match(r'(\d{1,2})[-_](.+)', base)
+    if m:
+        info['track'] = int(m.group(1))
+        title = m.group(2)
+    else:
+        title = base
+    info['title'] = title.replace('_', ' ').replace('-', ' ')
+    info['folder'] = path
+    # detect optional assets deviating from defaults
+    if not os.path.exists(os.path.join(path, 'karaoke.mp4')):
+        if os.path.exists(os.path.join(path, 'karaoke.mp4')) is False:
+            info['karaoke'] = None
+    stems = {}
+    stem_dir = os.path.join(path, 'stems')
+    if os.path.isdir(stem_dir):
+        for f in os.listdir(stem_dir):
+            if f.endswith('.wav'):
+                name = f.rsplit('.', 1)[0]
+                default = f'{name}.wav'
+                if f != default:
+                    stems[name] = os.path.join('stems', f)
+    if stems:
+        info['stems'] = stems
+    return info
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate songs.json for TraqLab')
+    parser.add_argument('patterns', nargs='+', help='Glob patterns to search for song files (e.g. albums/*/*/song.mp3)')
+    parser.add_argument('-o', '--output', default='traqlab/songs.json', help='Output JSON file path')
+    args = parser.parse_args()
+
+    albums = defaultdict(list)
+    for pattern in args.patterns:
+        for file in glob.glob(pattern):
+            song_dir = os.path.dirname(file)
+            album_dir = os.path.dirname(song_dir)
+            album_key = os.path.relpath(album_dir)
+            info = parse_song_dir(os.path.relpath(song_dir))
+            albums[album_key].append(info)
+
+    result = {'albums': []}
+    for album_dir in sorted(albums.keys()):
+        title = os.path.basename(album_dir).replace('_', ' ')
+        songs = sorted(albums[album_dir], key=lambda x: x.get('track', 0))
+        result['albums'].append({'title': title, 'path': album_dir, 'songs': songs})
+
+    with open(args.output, 'w') as f:
+        json.dump(result, f, indent=2)
+
+if __name__ == '__main__':
+    main()

--- a/traqlab/README.md
+++ b/traqlab/README.md
@@ -1,6 +1,6 @@
-# The Suicidal Kennedy's - Patriot Act Up
+# TraqLab - Multi-Album Practice Tool
 
-An interactive music learning platform showcasing the album "Patriot Act Up" by The Suicidal Kennedy's. This web application provides a sophisticated multi-track audio player with stem isolation, karaoke videos, and educational content for musicians.
+TraqLab is an interactive music learning platform for **The Suicidal Kennedy's**. Originally built for a single album, the site now supports multiple releases with a unified interface. Musicians can isolate stems, view lyrics, and practice along with karaoke videos.
 
 ## 🎵 Features
 
@@ -112,7 +112,15 @@ other.html        # For miscellaneous instruments
 
 ### 4. Update songs.json
 
-Add your song to the main configuration:
+Run the generator to rebuild the configuration. Provide a glob that matches your `song.mp3` or `song.wav` files:
+
+```bash
+python generate_songs_json.py albums/*/*/song.mp3
+```
+
+This creates `traqlab/songs.json` with all albums discovered in the path.
+
+If you prefer to edit manually, the structure for each song looks like:
 
 ```json
 {
@@ -159,7 +167,7 @@ Add your song to the main configuration:
 - Use MP4 format for broad compatibility
 - Include visual cues for timing and phrasing
 
-## 🎸 Current Album
+## 🎸 Albums
 
 **"Patriot Act Up"** features 14 tracks of political punk with themes including:
 - Amendment 22, Tariff Terror, Democracy's on Fire
@@ -168,6 +176,8 @@ Add your song to the main configuration:
 - Punk with Benefits, Break Free, Technocratic Descent, Trade War
 
 Each song includes professionally separated stems and educational content for musicians learning punk rock instrumentation.
+
+The follow-up record **"American Idle"** is also included with demo tracks and lyrics for early practice.
 
 ## 🚀 Development
 

--- a/traqlab/index.html
+++ b/traqlab/index.html
@@ -24,7 +24,7 @@
       margin: 0;
     }
     
-    .song-selector {
+    .selector {
       text-align: center;
       margin-bottom: 2rem;
     }
@@ -50,13 +50,19 @@
 <body>
   <div class="container">
     <header>
-      <img src="patriot_act_up.png" height="150" width="150">
+      <img id="albumArt" src="" height="150" width="150" alt="Album art">
       <span>
         <h1>The Suicidal Kennedy's</h1>
-        <h1>Patriot Act Up</h1>
+        <h1 id="albumTitle"></h1>
       </span>
     </header>
-    <div class="song-selector">
+    <div class="selector" id="albumSelector">
+      <label for="albumSelect">Choose an album:</label>
+      <select id="albumSelect">
+        <option value="">Select an album...</option>
+      </select>
+    </div>
+    <div class="selector song-selector">
       <label for="songSelect">Choose a song:</label>
       <select id="songSelect">
         <option value="">Select a song...</option>
@@ -69,22 +75,40 @@
   <script src="song-player.js"></script>
   <script>
     let songsData = null;
+    let currentAlbum = null;
 
     async function loadSongs() {
       try {
         const response = await fetch('songs.json');
         songsData = await response.json();
-        populateSelector();
+        populateAlbums();
       } catch (error) {
         console.error('Failed to load songs:', error);
       }
     }
 
-    function populateSelector() {
+    function populateAlbums() {
+      const select = document.getElementById('albumSelect');
+      songsData.albums.forEach((album, idx) => {
+        const option = document.createElement('option');
+        option.value = idx;
+        option.textContent = album.title;
+        select.appendChild(option);
+      });
+    }
+
+    function populateSongs(albumIndex) {
+      const album = songsData.albums[albumIndex];
+      if (!album) return;
+      currentAlbum = album;
+
+      const titleEl = document.getElementById('albumTitle');
+      titleEl.textContent = album.title;
+      document.getElementById('albumArt').src = `${album.path}/art.png`;
+
       const select = document.getElementById('songSelect');
-      const songs = songsData.songs.sort((a, b) => a.track - b.track);
-      
-      songs.forEach(song => {
+      select.innerHTML = '<option value="">Select a song...</option>';
+      album.songs.sort((a, b) => a.track - b.track).forEach(song => {
         const option = document.createElement('option');
         option.value = song.track;
         option.textContent = `${String(song.track).padStart(2, '0')}. ${song.title}`;
@@ -93,20 +117,27 @@
     }
 
     function loadSong(trackNumber) {
-      const song = songsData.songs.find(s => s.track == trackNumber);
+      if (!currentAlbum) return;
+      const song = currentAlbum.songs.find(s => s.track == trackNumber);
       if (!song) return;
 
       const container = document.getElementById('playerContainer');
       container.innerHTML = '';
-      
+
       const player = document.createElement('song-player');
       player.setAttribute('song-data', JSON.stringify(song));
       container.appendChild(player);
     }
 
+    document.getElementById('albumSelect').addEventListener('change', (e) => {
+      if (e.target.value !== '') {
+        populateSongs(parseInt(e.target.value));
+      }
+    });
+
     document.getElementById('songSelect').addEventListener('change', (e) => {
       if (e.target.value) {
-        loadSong(e.target.value);
+        loadSong(parseInt(e.target.value));
       }
     });
 

--- a/traqlab/songs.json
+++ b/traqlab/songs.json
@@ -1,246 +1,622 @@
 {
-  "album": "Patriot Act Up",
-  "songs": [
+  "albums": [
     {
-      "track": 1,
-      "folder": "albums/Patriot_Act_Up/Amendment_22",
-      "title": "Amendment 22",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Guitar", "html": "guitar.html", "stem": "stems/guitar.wav", "notes": "" },
-        { "name": "Bass", "html": "bass.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "other.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
+      "title": "Patriot Act Up",
+      "path": "albums/Patriot_Act_Up",
+      "songs": [
+        {
+          "track": 1,
+          "folder": "albums/Patriot_Act_Up/Amendment_22",
+          "title": "Amendment 22",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Guitar",
+              "html": "guitar.html",
+              "stem": "stems/guitar.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "bass.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "other.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 2,
+          "folder": "albums/Patriot_Act_Up/Tariff_Terror",
+          "title": "Tariff Terror",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Guitar",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/guitar.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "lead_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "other.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 3,
+          "folder": "albums/Patriot_Act_Up/Circlin_the_Drain",
+          "title": "Circlin' the Drain in a Limousine",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "lead_guitar.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 4,
+          "folder": "albums/Patriot_Act_Up/Democracys_on_Fire",
+          "title": "Democracy's on Fire",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Guitar",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/guitar.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "lead_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "other.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 5,
+          "folder": "albums/Patriot_Act_Up/Dept_of_Ignorance",
+          "title": "Education Soul Doubt",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Guitar",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/guitar.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "lead_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "other.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 6,
+          "folder": "albums/Patriot_Act_Up/Empty_Storefronts",
+          "title": "Empty Storefronts",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "lead_guitar.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 7,
+          "folder": "albums/Patriot_Act_Up/Great_Highway_to_Nowhere",
+          "title": "Great Highway to Nowhere",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "lead_guitar.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 8,
+          "folder": "albums/Patriot_Act_Up/Howl",
+          "title": "Coyotes Return",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "lead_guitar.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 9,
+          "folder": "albums/Patriot_Act_Up/Moron_Parade",
+          "title": "Moron Parade",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Other",
+              "html": "lead_guitar.html",
+              "stem": "stems/other.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 10,
+          "folder": "albums/Patriot_Act_Up/Prop_K_Parade",
+          "title": "Prop. K Parade",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "lead_guitar.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 11,
+          "folder": "albums/Patriot_Act_Up/Punk_With_Benefits",
+          "title": "Punk with Benefits",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "lead_guitar.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 12,
+          "folder": "albums/Patriot_Act_Up/Break_Free",
+          "title": "Break Free",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "lead_guitar.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 13,
+          "folder": "albums/Patriot_Act_Up/Technocratic_Descent",
+          "title": "Technocratic Descent",
+          "overview": "index.html",
+          "karaoke": "karaoke.mp4",
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "lead_guitar.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        },
+        {
+          "track": 14,
+          "folder": "albums/Patriot_Act_Up/Trade_War",
+          "title": "Trade War (for Money)",
+          "overview": "index.html",
+          "karaoke": null,
+          "audio": {
+            "mp3": "song.mp3",
+            "flac": "song.flac"
+          },
+          "parts": [
+            {
+              "name": "Drums",
+              "html": "drums.html",
+              "stem": "stems/drums.wav",
+              "notes": ""
+            },
+            {
+              "name": "Bass",
+              "html": "rhythm_guitar.html",
+              "stem": "stems/bass.wav",
+              "notes": ""
+            },
+            {
+              "name": "Instrumental",
+              "html": "lead_guitar.html",
+              "stem": "stems/instrumental.wav",
+              "notes": ""
+            },
+            {
+              "name": "Vocals",
+              "html": "vocals.html",
+              "stem": "stems/vocals.wav",
+              "notes": ""
+            }
+          ]
+        }
       ]
     },
     {
-      "track": 2,
-      "folder": "albums/Patriot_Act_Up/Tariff_Terror",
-      "title": "Tariff Terror",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Guitar", "html": "rhythm_guitar.html", "stem": "stems/guitar.wav", "notes": "" },
-        { "name": "Bass", "html": "lead_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "other.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-    {
-      "track": 3,
-      "folder": "albums/Patriot_Act_Up/Circlin_the_Drain",
-      "title": "Circlin' the Drain in a Limousine",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Bass", "html": "rhythm_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "lead_guitar.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-    {
-      "track": 4,
-      "folder": "albums/Patriot_Act_Up/Democracys_on_Fire",
-      "title": "Democracy's on Fire",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Guitar", "html": "rhythm_guitar.html", "stem": "stems/guitar.wav", "notes": "" },
-        { "name": "Bass", "html": "lead_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "other.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-    {
-      "track": 5,
-      "folder": "albums/Patriot_Act_Up/Dept_of_Ignorance",
-      "title": "Education Soul Doubt",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Guitar", "html": "rhythm_guitar.html", "stem": "stems/guitar.wav", "notes": "" },
-        { "name": "Bass", "html": "lead_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "other.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-    {
-      "track": 6,
-      "folder": "albums/Patriot_Act_Up/Empty_Storefronts",
-      "title": "Empty Storefronts",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Bass", "html": "rhythm_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "lead_guitar.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-    {
-      "track": 7,
-      "folder": "albums/Patriot_Act_Up/Great_Highway_to_Nowhere",
-      "title": "Great Highway to Nowhere",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Bass", "html": "rhythm_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "lead_guitar.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-    {
-      "track": 8,
-      "folder": "albums/Patriot_Act_Up/Howl",
-      "title": "Coyotes Return",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Bass", "html": "rhythm_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "lead_guitar.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-    {
-      "track": 9,
-      "folder": "albums/Patriot_Act_Up/Moron_Parade",
-      "title": "Moron Parade",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Bass", "html": "rhythm_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Other", "html": "lead_guitar.html", "stem": "stems/other.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-    {
-      "track": 10,
-      "folder": "albums/Patriot_Act_Up/Prop_K_Parade",
-      "title": "Prop. K Parade",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Bass", "html": "rhythm_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "lead_guitar.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-    {
-      "track": 11,
-      "folder": "albums/Patriot_Act_Up/Punk_With_Benefits",
-      "title": "Punk with Benefits",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "drums.wav", "notes": "" },
-        { "name": "Bass", "html": "rhythm_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "lead_guitar.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-   {
-      "track": 12,
-      "folder": "albums/Patriot_Act_Up/Break_Free",
-      "title": "Break Free",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Bass", "html": "rhythm_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "lead_guitar.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-     {
-      "track": 13,
-      "folder": "albums/Patriot_Act_Up/Technocratic_Descent",
-      "title": "Technocratic Descent",
-      "overview": "index.html",
-      "karaoke": "karaoke.mp4",
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Bass", "html": "rhythm_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "lead_guitar.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
-      ]
-    },
-    {
-      "track": 14,
-      "folder": "albums/Patriot_Act_Up/Trade_War",
-      "title": "Trade War (for Money)",
-      "overview": "index.html",
-      "karaoke": null,
-      "audio": {
-        "mp3": "song.mp3",
-        "flac": "song.flac"
-      },
-      "parts": [
-        { "name": "Drums", "html": "drums.html", "stem": "stems/drums.wav", "notes": "" },
-        { "name": "Bass", "html": "rhythm_guitar.html", "stem": "stems/bass.wav", "notes": "" },
-        { "name": "Instrumental", "html": "lead_guitar.html", "stem": "stems/instrumental.wav", "notes": "" },
-        { "name": "Vocals", "html": "vocals.html", "stem": "stems/vocals.wav", "notes": "" }
+      "title": "American Idle",
+      "path": "albums/American_Idle",
+      "songs": [
+        {
+          "track": 1,
+          "title": "Howl",
+          "folder": "albums/American_Idle/01_Howl"
+        },
+        {
+          "track": 2,
+          "title": "Swipe Left on Reality",
+          "folder": "albums/American_Idle/02_Swipe_Left_on_Reality"
+        },
+        {
+          "track": 3,
+          "title": "Empty Storefronts",
+          "folder": "albums/American_Idle/03_Empty_Storefronts"
+        },
+        {
+          "track": 4,
+          "title": "The Caulk Song",
+          "folder": "albums/American_Idle/04_The_Caulk_Song"
+        },
+        {
+          "track": 5,
+          "title": "Proposition K",
+          "folder": "albums/American_Idle/05_Proposition_K"
+        },
+        {
+          "track": 6,
+          "title": "Two Day Hangover Used to Be One",
+          "folder": "albums/American_Idle/06_Two_Day_Hangover_Used_to_Be_One"
+        },
+        {
+          "track": 7,
+          "title": "Punk With Benefits",
+          "folder": "albums/American_Idle/07_Punk_With_Benefits"
+        },
+        {
+          "track": 8,
+          "title": "Great Highway to Nowhere",
+          "folder": "albums/American_Idle/08_Great_Highway_to_Nowhere"
+        },
+        {
+          "track": 9,
+          "title": "Cooler Online",
+          "folder": "albums/American_Idle/09_Cooler_Online"
+        },
+        {
+          "track": 10,
+          "title": "Bored of Education",
+          "folder": "albums/American_Idle/10_Bored_of_Education"
+        },
+        {
+          "track": 11,
+          "title": "Truth Decay",
+          "folder": "albums/American_Idle/11_Truth_Decay"
+        },
+        {
+          "track": 12,
+          "title": "Skatepark Nostalgia",
+          "folder": "albums/American_Idle/12_Skatepark_Nostalgia"
+        },
+        {
+          "track": 13,
+          "title": "Break Free",
+          "folder": "albums/American_Idle/13_Break_Free"
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- restructure `songs.json` to support multiple albums
- implement album selection in `index.html`
- add generator script `generate_songs_json.py`
- update README with new workflow

## Testing
- `python3 -m py_compile generate_songs_json.py`
- `python3 generate_songs_json.py albums/*/*/song.mid -o /tmp/out.json`

------
https://chatgpt.com/codex/tasks/task_e_686b1c8d30cc8323ac07b011e1130d28